### PR TITLE
Add MingleBerryMedia as DeAI Manifesto signee

### DIFF
--- a/src/DeAIManifesto_frontend/src/helpers/organization_signees.js
+++ b/src/DeAIManifesto_frontend/src/helpers/organization_signees.js
@@ -71,5 +71,12 @@ export const organizationSignees = [
     signDate: "2024-12-10",
     signedBy: "Jayz",
   },
+  {
+    name: "MingleBerryMedia",
+    logo: "./MingleBerryMedia-logo-organization-signee.jpg",
+    url: "https://mingleberrymedia.com/",
+    signDate: "2024-12-16",
+    signedBy: "hankolious",
+  },
 ];
   


### PR DESCRIPTION
This pull request adds MingleBerryMedia as a signee to the DeAI Manifesto. 
- Added MingleBerryMedia's entry to organization_signees.js